### PR TITLE
feat: initial region chart rendering

### DIFF
--- a/mocks/helpers/parseRegions.ts
+++ b/mocks/helpers/parseRegions.ts
@@ -1,22 +1,29 @@
+export type RegionResultValue = "true" | "false" | "unknown" | "partially";
 export interface RegionResult {
-  value: boolean | "unknown" | "partially";
+  value: RegionResultValue;
   params: Record<string, { from: number; to: number }>;
 }
 
 export type RegionResultsRaw = Array<Record<string, string>>;
 export type RegionResults = Array<RegionResult>;
 
+export const parseFraction = (fract: string) => {
+  if (!fract.includes("/")) return parseInt(fract, 10);
+  const splitted = fract.split("/");
+  return parseInt(splitted[0], 10) / parseInt(splitted[1], 10);
+};
+
 export const parseParam = (param: string) => {
   const spiltted = param.split("<=");
-  return { to: parseInt(spiltted[0], 10), from: parseInt(spiltted[2], 10) };
+  return { from: parseFraction(spiltted[0]), to: parseFraction(spiltted[2]) };
 };
 
 export const parseValue = (value: string): RegionResult["value"] => {
   switch (value) {
     case "AllSat":
-      return true;
+      return "true";
     case "AllViolated":
-      return false;
+      return "false";
     case "ExistsSat":
       return "partially";
     default:
@@ -29,12 +36,14 @@ export const csvToRegionResultsList = (
 ): RegionResults => {
   return raw.map((result) => {
     const value = parseValue(result["value"]);
-    delete result["value"];
 
     return {
       value,
       params: Object.keys(result).reduce<RegionResult["params"]>(
-        (params, param) => ({ ...params, [param]: parseParam(result[param]) }),
+        (params, param) =>
+          param !== "value"
+            ? { ...params, [param]: parseParam(result[param]) }
+            : params,
         {}
       ),
     };

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -1,4 +1,6 @@
 import RegionResults01 from "./data/regionResults01.csv";
-import { csvToRegionResultsList } from "./helpers/parseRegions";
+import { csvToRegionResultsList, RegionResults } from "./helpers/parseRegions";
 
-export const RegionResults01Parsed = csvToRegionResultsList(RegionResults01);
+export const RegionResults01Parsed:
+  | RegionResults
+  | undefined = csvToRegionResultsList(RegionResults01);

--- a/src/Visualizer.stories.tsx
+++ b/src/Visualizer.stories.tsx
@@ -8,7 +8,8 @@ export default {
   component: Visualizer,
 };
 
+const mockData = RegionResults01Parsed ?? [];
+
 export const Basic = () => {
-  console.log(RegionResults01Parsed);
-  return <Visualizer />;
+  return <Visualizer data={mockData} />;
 };

--- a/src/Visualizer.tsx
+++ b/src/Visualizer.tsx
@@ -1,7 +1,114 @@
-import React from "react";
+import React, { useEffect, useMemo, useRef } from "react";
+import { RegionResults, RegionResultValue } from "@mocks/helpers/parseRegions";
+import { getParamDomain, getParams } from "./helpers/regionsTransforms";
+import { extent } from "d3-array";
+import { scaleLinear } from "d3-scale";
+import { select } from "d3-selection";
+import { axisBottom, axisLeft } from "d3-axis";
 
-const Visualizer = () => {
-  return <div>Hello world!</div>;
+type Props = {
+  data: RegionResults;
+};
+
+const FIXED_WIDTH = 600;
+const FIXED_HEIGHT = 600;
+
+const COLOR_MAPPING: Record<RegionResultValue, string> = {
+  true: "#f4c941",
+  false: "#b30e17",
+  unknown: "#fde6c4",
+  partially: "#fde6c4",
+};
+
+const Visualizer = ({ data }: Props) => {
+  const params = useMemo(() => getParams(data), [data]);
+
+  const paramsExtent = useMemo(
+    () =>
+      params.reduce<Record<string, [number, number]>>((acc, param) => {
+        const paramExtent = extent(getParamDomain(data, param));
+        const [min, max] = paramExtent;
+
+        if (!min || !max) return acc;
+
+        return {
+          ...acc,
+          [param]: paramExtent,
+        };
+      }, {}),
+    [data, params]
+  );
+
+  console.log(paramsExtent);
+
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
+  useEffect(() => {
+    // TEMP: Fixed values for scale
+    const xScale = scaleLinear()
+      .domain(paramsExtent[params[0]])
+      .range([0, FIXED_WIDTH]);
+
+    // TEMP: Fixed values for scale
+    const yScale = scaleLinear()
+      .domain(paramsExtent[params[1]])
+      .range([0, FIXED_HEIGHT]);
+
+    const svgEl = select(svgRef.current);
+
+    svgEl.selectAll("*").remove();
+
+    const svg = svgEl.append("g");
+    console.log(data);
+    svg
+      .append("g")
+      .selectAll("rect")
+      .data(data)
+      .join("rect")
+      .attr("fill", (d) => COLOR_MAPPING[d.value])
+      .attr("x", (d) => xScale(d.params[params[0]].from))
+      .attr("y", (d) => yScale(d.params[params[1]].from))
+      .attr(
+        "width",
+        (d) => xScale(d.params[params[0]].to) - xScale(d.params[params[0]].from)
+      )
+      .attr(
+        "height",
+        (d) => yScale(d.params[params[1]].to) - yScale(d.params[params[1]].from)
+      );
+
+    const xAxis = axisBottom(xScale).ticks(5).tickSize(-FIXED_HEIGHT);
+    const xAxisGroup = svg
+      .append("g")
+      .attr("transform", `translate(0, ${FIXED_HEIGHT})`)
+      .call(xAxis);
+
+    xAxisGroup.select(".domain").remove();
+    xAxisGroup.selectAll("line").attr("stroke", "rgba(0, 0, 0, 0.2)");
+    xAxisGroup
+      .selectAll("text")
+      .attr("opacity", 0.5)
+      .attr("color", "black")
+      .attr("font-size", "0.75rem");
+
+    const yAxis = axisLeft(yScale).ticks(5).tickSize(-FIXED_WIDTH);
+
+    const yAxisGroup = svg
+      .append("g")
+      .attr("transform", `translate(32, 0)`)
+      .call(yAxis);
+    yAxisGroup.select(".domain").remove();
+    yAxisGroup.selectAll("line").attr("stroke", "rgba(0, 0, 0, 0.2)");
+    yAxisGroup
+      .selectAll("text")
+      .attr("opacity", 0.5)
+      .attr("color", "black")
+      .attr("font-size", "0.75rem");
+  }, [paramsExtent, params, data]);
+
+  return (
+    <svg ref={svgRef} width={FIXED_WIDTH + 16} height={FIXED_HEIGHT + 16} />
+  );
 };
 
 export default Visualizer;

--- a/src/helpers/regionsTransforms.ts
+++ b/src/helpers/regionsTransforms.ts
@@ -1,0 +1,13 @@
+import { RegionResults } from "@mocks/helpers/parseRegions";
+
+export const getParams = (regions: RegionResults) =>
+  regions.length > 0 ? Object.keys(regions[0].params) : [];
+
+export const getParamDomain = (regions: RegionResults, param: string) =>
+  regions.reduce<number[]>((acc, region) => {
+    const paramRange = region.params[param];
+
+    if (!paramRange) return acc;
+
+    return [...acc, paramRange.from, paramRange.to];
+  }, []);


### PR DESCRIPTION
Implement initial rendering of region chart. Fixed few bugs in data parsing.

Still a bit raw:
![image](https://user-images.githubusercontent.com/9140387/138505040-ad32e735-52e9-4089-be5f-33b47358f4a6.png)
