### PR TITLE
Feat/zooming

### DIFF
--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -2,12 +2,13 @@ import { select, Selection } from "d3";
 import ChartArea from "./components/ChartArea";
 import Config from "./Config";
 import { ChartConfig, DatumRect, MountElement } from "./types/general";
+import { SimpleSelection } from "./types/selection";
 
 class Chart<Datum> {
-  protected el?: Selection<HTMLDivElement, unknown, null, undefined>;
+  protected el?: SimpleSelection<HTMLDivElement>;
   protected config: Config<Datum>;
   protected chartArea?: ChartArea<DatumRect<Datum>>;
-  protected svg?: Selection<SVGSVGElement, unknown, null, undefined>;
+  protected svg?: SimpleSelection<SVGSVGElement>;
 
   private _width: number;
   private _height: number;
@@ -36,9 +37,7 @@ class Chart<Datum> {
     return this;
   }
 
-  private initSVG(
-    element: Selection<HTMLDivElement, unknown, null, undefined>
-  ) {
+  private initSVG(element: SimpleSelection<HTMLDivElement>) {
     const { width, height } = this;
 
     this.svg = element.append("svg");
@@ -50,9 +49,7 @@ class Chart<Datum> {
     return this;
   }
 
-  private initChartArea(
-    element: Selection<HTMLDivElement, unknown, null, undefined>
-  ) {
+  private initChartArea(element: SimpleSelection<HTMLDivElement>) {
     const { width, height, config } = this;
     this.chartArea = new ChartArea(element, width, height);
 

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -9,7 +9,7 @@ class Chart<Datum> {
   protected el?: SimpleSelection<HTMLDivElement>;
   protected config: Config<Datum>;
   protected chartArea?: ChartArea<DatumRect<Datum>>;
-  protected svg?: SimpleSelection<SVGSVGElement>;
+  protected svg?: SimpleSelection<SVGGElement>;
   protected margin: Margin = ZERO_MARGIN;
 
   private _width: number;
@@ -42,20 +42,25 @@ class Chart<Datum> {
   }
 
   private initSVG(element: SimpleSelection<HTMLDivElement>) {
-    const { width, height } = this;
+    const { width, height, margin } = this;
 
-    this.svg = element.append("svg");
-    this.svg
+    this.svg = element
+      .append("svg")
       .attr("width", width)
       .attr("height", height)
-      .style("position", "absolute");
+      .style("position", "absolute")
+      .append("g");
+    this.svg.attr(
+      "transform",
+      "translate(" + margin.left + " " + margin.top + ")"
+    );
 
     return this;
   }
 
   private initChartArea(element: SimpleSelection<HTMLDivElement>) {
-    const { width, height, config } = this;
-    this.chartArea = new ChartArea(element, width, height);
+    const { xMax, yMax, margin } = this;
+    this.chartArea = new ChartArea(element, xMax, yMax, margin);
 
     return this;
   }
@@ -66,6 +71,16 @@ class Chart<Datum> {
 
   get height() {
     return this._height;
+  }
+
+  get xMax() {
+    const { margin } = this;
+    return this._width - margin.left - margin.right;
+  }
+
+  get yMax() {
+    const { margin } = this;
+    return this._height - margin.top - margin.bottom;
   }
 }
 

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -1,7 +1,8 @@
 import { select, Selection } from "d3";
 import ChartArea from "./components/ChartArea";
 import Config from "./Config";
-import { ChartConfig, DatumRect, MountElement } from "./types/general";
+import { ZERO_MARGIN } from "./constants/common";
+import { ChartConfig, DatumRect, Margin, MountElement } from "./types/general";
 import { SimpleSelection } from "./types/selection";
 
 class Chart<Datum> {
@@ -9,12 +10,15 @@ class Chart<Datum> {
   protected config: Config<Datum>;
   protected chartArea?: ChartArea<DatumRect<Datum>>;
   protected svg?: SimpleSelection<SVGSVGElement>;
+  protected margin: Margin = ZERO_MARGIN;
 
   private _width: number;
   private _height: number;
 
   constructor(element: MountElement, config: ChartConfig<Datum>) {
     this.config = new Config(config);
+
+    this.margin = this.config.options?.margin ?? this.margin;
 
     this._height = config.height;
     this._width = config.width;

--- a/src/RegionsChart.ts
+++ b/src/RegionsChart.ts
@@ -7,14 +7,12 @@ import {
 } from "d3";
 
 import Chart from "./Chart";
-import { ZERO_MARGIN } from "./constants/common";
 import RegionsController from "./controllers/RegionsController";
 import Zoom from "./controllers/Zoom";
 import { xAxisFactory, yAxisFactory } from "./helpers/axis";
 import {
   ChartConfig,
   DatumRect,
-  Margin,
   MountElement,
   RegionDatum,
 } from "./types/general";
@@ -28,13 +26,10 @@ class RegionsChart<Value> extends Chart<RegionDatum<Value>> {
   private gy?: SimpleSelection<SVGGElement>;
   private zoom?: Zoom<HTMLCanvasElement>;
 
-  private margin: Margin = ZERO_MARGIN;
-
   constructor(element: MountElement, config: ChartConfig<RegionDatum<Value>>) {
     super(element, config);
 
     const { width, height, chartArea } = this;
-    this.margin = this.config.options?.margin ?? this.margin;
 
     this.dataController = new RegionsController(
       {

--- a/src/RegionsChart.ts
+++ b/src/RegionsChart.ts
@@ -1,10 +1,4 @@
-import {
-  ScaleLinear,
-  select,
-  Selection,
-  zoomIdentity,
-  ZoomTransform,
-} from "d3";
+import { select, zoomIdentity, ZoomTransform } from "d3";
 
 import Chart from "./Chart";
 import RegionsController from "./controllers/RegionsController";
@@ -29,14 +23,13 @@ class RegionsChart<Value> extends Chart<RegionDatum<Value>> {
   constructor(element: MountElement, config: ChartConfig<RegionDatum<Value>>) {
     super(element, config);
 
-    const { width, height, chartArea } = this;
+    const { xMax, yMax, chartArea } = this;
 
     this.dataController = new RegionsController(
       {
-        width,
-        height,
+        width: xMax,
+        height: yMax,
         data: this.config.data,
-        margin: this.margin,
       },
       this.config.params
     );
@@ -88,37 +81,32 @@ class RegionsChart<Value> extends Chart<RegionDatum<Value>> {
   }
 
   private redrawAxes = (transform: ZoomTransform) => {
-    const { height, margin } = this;
+    const { yMax } = this;
     const [xScale, yScale] = this.dataController.currentScales;
 
     if (!xScale) return;
 
     this.gx?.call(
-      xAxisFactory(
-        height,
-        margin,
-        transform.rescaleX(xScale.scale) as AnyD3Scale
-      )
+      xAxisFactory(yMax, transform.rescaleX(xScale.scale) as AnyD3Scale)
     );
 
     if (yScale)
       this.gy?.call(
-        yAxisFactory(margin, transform.rescaleY(yScale.scale) as AnyD3Scale)
+        yAxisFactory(transform.rescaleY(yScale.scale) as AnyD3Scale)
       );
   };
 
   private initAxes() {
-    const { svg, height, margin } = this;
+    const { svg, yMax } = this;
     const [xScale, yScale] = this.dataController.currentScales;
 
     // X scale should be always defined, if not, something went wrong
     if (!xScale) return;
 
-    this.gx = svg?.append("g").call(xAxisFactory(height, margin, xScale.scale));
+    this.gx = svg?.append("g").call(xAxisFactory(yMax, xScale.scale));
 
     // Y scale is not guaranteed, since the chart supports 1D chart
-    if (yScale)
-      this.gy = svg?.append("g").call(yAxisFactory(margin, yScale.scale));
+    if (yScale) this.gy = svg?.append("g").call(yAxisFactory(yScale.scale));
   }
 
   private initHighlightLayer() {

--- a/src/RegionsChart.ts
+++ b/src/RegionsChart.ts
@@ -70,9 +70,17 @@ class RegionsChart<Value> extends Chart<RegionDatum<Value>> {
   }
 
   private initZoom() {
+    const { xMax, yMax } = this;
+
     const [xScale] = this.dataController.currentScales;
     if (xScale) {
-      this.zoom = new Zoom([1, 10]);
+      this.zoom = new Zoom(
+        [1, 10],
+        [
+          [0, 0],
+          [xMax, yMax],
+        ]
+      );
       this.chartArea?.canvas.call(this.zoom?.zoom);
 
       this.zoom.onChange(this.redrawAxes);

--- a/src/RegionsChart.ts
+++ b/src/RegionsChart.ts
@@ -11,10 +11,13 @@ import {
   MountElement,
   RegionDatum,
 } from "./types/general";
+import { SimpleSelection } from "./types/selection";
 
 class RegionsChart<Value> extends Chart<RegionDatum<Value>> {
   private dataController: RegionsController<Value>;
-  private highlight?: Selection<SVGRectElement, unknown, null, undefined>;
+  private highlight?: SimpleSelection<SVGRectElement>;
+  private gx?: SimpleSelection<SVGGElement>;
+  private gy?: SimpleSelection<SVGGElement>;
 
   private margin: Margin = ZERO_MARGIN;
 
@@ -76,10 +79,11 @@ class RegionsChart<Value> extends Chart<RegionDatum<Value>> {
     // X scale should be always defined, if not, something went wrong
     if (!xScale) return;
 
-    svg?.append("g").call(xAxisFactory(height, margin, xScale.scale));
+    this.gx = svg?.append("g").call(xAxisFactory(height, margin, xScale.scale));
 
     // Y scale is not guaranteed, since the chart supports 1D chart
-    if (yScale) svg?.append("g").call(yAxisFactory(margin, yScale.scale));
+    if (yScale)
+      this.gy = svg?.append("g").call(yAxisFactory(margin, yScale.scale));
   }
 
   private initHighlightLayer() {

--- a/src/RegionsChart.ts
+++ b/src/RegionsChart.ts
@@ -63,6 +63,7 @@ class RegionsChart<Value> extends Chart<RegionDatum<Value>> {
     if (!highlight) return;
 
     highlight
+      .style("display", "initial")
       .attr("x", x)
       .attr("y", y)
       .attr("width", width)
@@ -85,6 +86,10 @@ class RegionsChart<Value> extends Chart<RegionDatum<Value>> {
 
       this.zoom.onChange(this.redrawAxes);
       this.zoom.onChange(this.redraw);
+      this.zoom.onChange((t) => {
+        if (this.chartArea) this.chartArea.transform = t;
+        this.highlight?.style("display", "none");
+      });
     }
   }
 

--- a/src/RegionsChart.ts
+++ b/src/RegionsChart.ts
@@ -131,8 +131,8 @@ class RegionsChart<Value> extends Chart<RegionDatum<Value>> {
 
     this.highlight
       ?.attr("fill", "transparent")
-      .attr("stroke", "#000")
-      .attr("stroke-width", 2);
+      .attr("stroke", "#9b9b9b")
+      .attr("stroke-width", 3);
   }
 
   private redraw = (transform: ZoomTransform = zoomIdentity) => {

--- a/src/components/ChartArea.ts
+++ b/src/components/ChartArea.ts
@@ -10,7 +10,7 @@ export type ChartAreaMouseEventCb<Datum extends {}> = (data: Datum[]) => void;
 
 class ChartArea<Datum extends Rect> {
   private container: SimpleSelection<HTMLDivElement>;
-  private canvas: SimpleSelection<HTMLCanvasElement>;
+  private _canvas: SimpleSelection<HTMLCanvasElement>;
   private _svg: SimpleSelection<SVGSVGElement>;
 
   private _data?: QuadTree;
@@ -19,9 +19,10 @@ class ChartArea<Datum extends Rect> {
     this.container = root
       .append("div")
       .classed("chart-area", true)
-      .style("position", "absolute");
+      .style("position", "absolute")
+      .style("transform", "translate(1px, 1px)"); // TODO: should reflect axis stroke-width
 
-    this.canvas = this.container
+    this._canvas = this.container
       .append("canvas")
       .attr("width", w)
       .attr("height", h)
@@ -36,15 +37,15 @@ class ChartArea<Datum extends Rect> {
   }
 
   public data(value: Datum[]) {
-    const canvas = this.canvas.node();
+    const _canvas = this._canvas.node();
 
-    if (canvas)
+    if (_canvas)
       this._data = new QuadTree(
         {
           x: 0,
           y: 0,
-          width: canvas.width,
-          height: canvas.height,
+          width: _canvas.width,
+          height: _canvas.height,
         },
         4,
         200
@@ -72,11 +73,15 @@ class ChartArea<Datum extends Rect> {
 
       callback(data ?? []);
     };
-    this.canvas.on(name, eventHandler);
+    this._canvas.on(name, eventHandler);
+  }
+
+  get canvas() {
+    return this._canvas;
   }
 
   get context() {
-    return this.canvas.node()?.getContext("2d");
+    return this._canvas.node()?.getContext("2d");
   }
 
   get svg() {

--- a/src/components/ChartArea.ts
+++ b/src/components/ChartArea.ts
@@ -3,22 +3,19 @@ import QuadTree, { Rect } from "@timohausmann/quadtree-js";
 
 // import QuadTree, { Accessor } from "../lib/QuadTree";
 import { rectsOverlapping } from "../helpers/canvas";
+import { SimpleSelection } from "../types/selection";
 
 export type ChartAreaMouseEvents = "mousemove" | "mouseover" | "mouseout";
 export type ChartAreaMouseEventCb<Datum extends {}> = (data: Datum[]) => void;
 
 class ChartArea<Datum extends Rect> {
-  private container: Selection<HTMLDivElement, unknown, null, undefined>;
-  private canvas: Selection<HTMLCanvasElement, unknown, null, undefined>;
-  private _svg: Selection<SVGSVGElement, unknown, null, undefined>;
+  private container: SimpleSelection<HTMLDivElement>;
+  private canvas: SimpleSelection<HTMLCanvasElement>;
+  private _svg: SimpleSelection<SVGSVGElement>;
 
   private _data?: QuadTree;
 
-  constructor(
-    root: Selection<HTMLDivElement, unknown, null, undefined>,
-    w: number,
-    h: number
-  ) {
+  constructor(root: SimpleSelection<HTMLDivElement>, w: number, h: number) {
     this.container = root
       .append("div")
       .classed("chart-area", true)

--- a/src/components/ChartArea.ts
+++ b/src/components/ChartArea.ts
@@ -4,6 +4,7 @@ import QuadTree, { Rect } from "@timohausmann/quadtree-js";
 // import QuadTree, { Accessor } from "../lib/QuadTree";
 import { rectsOverlapping } from "../helpers/canvas";
 import { SimpleSelection } from "../types/selection";
+import { Margin } from "../types/general";
 
 export type ChartAreaMouseEvents = "mousemove" | "mouseover" | "mouseout";
 export type ChartAreaMouseEventCb<Datum extends {}> = (data: Datum[]) => void;
@@ -15,12 +16,17 @@ class ChartArea<Datum extends Rect> {
 
   private _data?: QuadTree;
 
-  constructor(root: SimpleSelection<HTMLDivElement>, w: number, h: number) {
+  constructor(
+    root: SimpleSelection<HTMLDivElement>,
+    w: number,
+    h: number,
+    m: Margin
+  ) {
     this.container = root
       .append("div")
       .classed("chart-area", true)
       .style("position", "absolute")
-      .style("transform", "translate(1px, 1px)"); // TODO: should reflect axis stroke-width
+      .style("transform", "translate(" + m.left + "px,  " + m.top + "px)");
 
     this._canvas = this.container
       .append("canvas")

--- a/src/controllers/DataController.ts
+++ b/src/controllers/DataController.ts
@@ -21,7 +21,6 @@ export type DataControllerOptions<T> = {
   data: T;
   width: number;
   height: number;
-  margin: Margin;
 };
 
 class DataController<Datum, Data extends Array<Datum> = Array<Datum>> {

--- a/src/controllers/RegionsController.ts
+++ b/src/controllers/RegionsController.ts
@@ -1,6 +1,5 @@
 import { BaseType, Selection } from "d3-selection";
 import { UNDEFINED_CHART_VALUE } from "../constants/common";
-import { getScaleRange } from "../helpers/scale";
 import { RegionDatum, ParamsTuple, Margin } from "../types/general";
 import DataController, { DataControllerOptions } from "./DataController";
 
@@ -18,9 +17,9 @@ class RegionsController<Value> extends DataController<RegionDatum<Value>> {
   ) {
     super(opts, params);
 
-    const { width, height, margin } = opts;
+    const { width, height } = opts;
 
-    this._initRegionsBinding(width, height, margin);
+    this._initRegionsBinding(width, height);
   }
 
   public x = (d: RegionDatum<Value>) => {
@@ -57,11 +56,13 @@ class RegionsController<Value> extends DataController<RegionDatum<Value>> {
       : UNDEFINED_CHART_VALUE;
   };
 
-  private _initRegionsBinding(w: number, h: number, m: Margin) {
+  private _initRegionsBinding(w: number, h: number) {
     const [xScale, yScale] = this.currentScales;
 
-    xScale?.scale.range(getScaleRange("x", w, m));
-    yScale?.scale.range(getScaleRange("y", h, m));
+    if (!xScale) return;
+
+    xScale?.scale.range([0, w]);
+    yScale?.scale.range([h, 0]);
 
     // Bind zero for y position and height in case of 1D chart
     this._regionsBinding = this.dataBinding

--- a/src/controllers/Zoom.ts
+++ b/src/controllers/Zoom.ts
@@ -1,40 +1,26 @@
 import { zoom, ZoomedElementBaseType, ZoomTransform, ZoomScale } from "d3";
 
-type ZoomListener<XScale, YScale> = (xScale: XScale, yScale?: YScale) => void;
+type ZoomListener = (translate: ZoomTransform) => void;
 
-class Zoom<
-  ZoomRefElement extends ZoomedElementBaseType,
-  XScale extends ZoomScale,
-  YScale extends ZoomScale
-> {
-  private xScale: XScale;
-  private yScale?: YScale;
-
-  private zoomListeners: ZoomListener<XScale, YScale>[] = [];
+class Zoom<ZoomRefElement extends ZoomedElementBaseType> {
+  private zoomListeners: ZoomListener[] = [];
 
   // Zoom behaviour, this should be attached to the zoom base (svg, canvas, etc.)
   public zoom = zoom<ZoomRefElement, unknown>();
 
-  constructor(xScale: XScale, yScale?: YScale, scaleExtent?: [number, number]) {
-    this.xScale = xScale;
-    this.yScale = yScale;
-
+  constructor(scaleExtent?: [number, number]) {
     if (scaleExtent) this.zoom.scaleExtent(scaleExtent);
     this.zoom.on("zoom", this.handleZoom);
   }
 
-  public onChange(listener: ZoomListener<XScale, YScale>) {
+  public onChange(listener: ZoomListener) {
     this.zoomListeners.push(listener);
   }
 
   private handleZoom = (event: any) => {
     const transform: ZoomTransform = event.transform;
 
-    let updatedY: YScale;
-    const updatedX = transform.rescaleX(this.xScale);
-    if (this.yScale) updatedY = transform.rescaleY(this.yScale);
-
-    this.zoomListeners.forEach((cb) => cb(updatedX, updatedY));
+    this.zoomListeners.forEach((cb) => cb(transform));
   };
 }
 

--- a/src/controllers/Zoom.ts
+++ b/src/controllers/Zoom.ts
@@ -1,0 +1,41 @@
+import { zoom, ZoomedElementBaseType, ZoomTransform, ZoomScale } from "d3";
+
+type ZoomListener<XScale, YScale> = (xScale: XScale, yScale?: YScale) => void;
+
+class Zoom<
+  ZoomRefElement extends ZoomedElementBaseType,
+  XScale extends ZoomScale,
+  YScale extends ZoomScale
+> {
+  private xScale: XScale;
+  private yScale?: YScale;
+
+  private zoomListeners: ZoomListener<XScale, YScale>[] = [];
+
+  // Zoom behaviour, this should be attached to the zoom base (svg, canvas, etc.)
+  public zoom = zoom<ZoomRefElement, unknown>();
+
+  constructor(xScale: XScale, yScale?: YScale, scaleExtent?: [number, number]) {
+    this.xScale = xScale;
+    this.yScale = yScale;
+
+    if (scaleExtent) this.zoom.scaleExtent(scaleExtent);
+    this.zoom.on("zoom", this.handleZoom);
+  }
+
+  public onChange(listener: ZoomListener<XScale, YScale>) {
+    this.zoomListeners.push(listener);
+  }
+
+  private handleZoom = (event: any) => {
+    const transform: ZoomTransform = event.transform;
+
+    let updatedY: YScale;
+    const updatedX = transform.rescaleX(this.xScale);
+    if (this.yScale) updatedY = transform.rescaleY(this.yScale);
+
+    this.zoomListeners.forEach((cb) => cb(updatedX, updatedY));
+  };
+}
+
+export default Zoom;

--- a/src/controllers/Zoom.ts
+++ b/src/controllers/Zoom.ts
@@ -8,8 +8,14 @@ class Zoom<ZoomRefElement extends ZoomedElementBaseType> {
   // Zoom behaviour, this should be attached to the zoom base (svg, canvas, etc.)
   public zoom = zoom<ZoomRefElement, unknown>();
 
-  constructor(scaleExtent?: [number, number]) {
+  constructor(
+    scaleExtent?: [number, number],
+    translateExtent?: [[number, number], [number, number]]
+  ) {
     if (scaleExtent) this.zoom.scaleExtent(scaleExtent);
+
+    if (translateExtent) this.zoom.translateExtent(translateExtent);
+
     this.zoom.on("zoom", this.handleZoom);
   }
 

--- a/src/helpers/axis.ts
+++ b/src/helpers/axis.ts
@@ -1,5 +1,4 @@
 import { axisBottom, axisLeft } from "d3";
-import { Margin } from "../types/general";
 import { AnyD3Scale } from "../types/scale";
 import { SimpleSelection } from "../types/selection";
 

--- a/src/helpers/axis.ts
+++ b/src/helpers/axis.ts
@@ -1,15 +1,15 @@
 import { axisBottom, axisLeft, Selection } from "d3";
 import { Margin } from "../types/general";
 import { AnyD3Scale } from "../types/scale";
+import { SimpleSelection } from "../types/selection";
 
 export const xAxisFactory =
   (height: number, margin: Margin, xScale: AnyD3Scale) =>
-  (g: Selection<SVGGElement, unknown, null, undefined>) =>
+  (g: SimpleSelection<SVGGElement>) =>
     g
       .attr("transform", `translate(0,${height - margin.bottom})`)
       .call(axisBottom(xScale));
 
 export const yAxisFactory =
-  (margin: Margin, yScale: AnyD3Scale) =>
-  (g: Selection<SVGGElement, unknown, null, undefined>) =>
+  (margin: Margin, yScale: AnyD3Scale) => (g: SimpleSelection<SVGGElement>) =>
     g.attr("transform", `translate(${margin.left},0)`).call(axisLeft(yScale));

--- a/src/helpers/axis.ts
+++ b/src/helpers/axis.ts
@@ -1,15 +1,17 @@
-import { axisBottom, axisLeft, Selection } from "d3";
+import { axisBottom, axisLeft } from "d3";
 import { Margin } from "../types/general";
 import { AnyD3Scale } from "../types/scale";
 import { SimpleSelection } from "../types/selection";
 
 export const xAxisFactory =
-  (height: number, margin: Margin, xScale: AnyD3Scale) =>
+  (height: number, xScale: AnyD3Scale, stroke = 1) =>
   (g: SimpleSelection<SVGGElement>) =>
     g
-      .attr("transform", `translate(0,${height - margin.bottom})`)
-      .call(axisBottom(xScale));
+      .attr("transform", `translate(0,${height})`)
+      .call(axisBottom(xScale))
+      .attr("stroke-width", stroke);
 
 export const yAxisFactory =
-  (margin: Margin, yScale: AnyD3Scale) => (g: SimpleSelection<SVGGElement>) =>
-    g.attr("transform", `translate(${margin.left},0)`).call(axisLeft(yScale));
+  (yScale: AnyD3Scale, stroke = 1) =>
+  (g: SimpleSelection<SVGGElement>) =>
+    g.call(axisLeft(yScale)).attr("stroke-width", stroke);

--- a/src/helpers/regions.ts
+++ b/src/helpers/regions.ts
@@ -25,17 +25,3 @@ export const getParamDomain = <Value>(
 
     return [...acc, paramRange.from, paramRange.to];
   }, []);
-
-export const getMarginWithAxes = (
-  margin: Margin,
-  tickFontSize: number,
-  tickSize: number
-): Margin => {
-  return {
-    ...margin,
-    top: (margin.top ?? 0) + tickFontSize + tickSize,
-    bottom: (margin.bottom ?? 0) + tickFontSize + tickSize,
-    right: (margin.right ?? 0) + tickFontSize + tickSize,
-    left: (margin.left ?? 0) + tickFontSize + tickSize,
-  };
-};

--- a/src/helpers/scale.ts
+++ b/src/helpers/scale.ts
@@ -26,12 +26,3 @@ export const getTicksFormatter = <Scale extends AnyD3Scale>(
 
   return (d: ScaleInput<Scale>) => d.toString();
 };
-
-export const getScaleRange = (
-  type: "x" | "y",
-  size: number,
-  margin: Margin
-) => {
-  if (type === "x") return [margin.left ?? 0, size - (margin.right ?? 0)];
-  return [size - (margin.bottom ?? 0), margin.top ?? 0];
-};

--- a/src/types/selection.ts
+++ b/src/types/selection.ts
@@ -1,0 +1,8 @@
+import { BaseType, Selection } from "d3-selection";
+
+export type SimpleSelection<GElement extends BaseType> = Selection<
+  GElement,
+  unknown,
+  null,
+  undefined
+>;


### PR DESCRIPTION
Implemented a simple class that handles the chart zoom. Axes are scaled accordingly to the zoom transform and the chart area canvas is redrawn on each scale re-scale (triggered by the zoom). 

Another challenge was to correctly retrieve regions from the chart area quadtree, this is achieved by inverting pointer coordinates, retrieving correct quads, and then transforming them before passing to the ChartArea mouse callback.